### PR TITLE
updated for python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 Works with Python 2, NOT Python 3
 
-## TODO: update for Python 3
+## TODO: 
+-update for Python 3
+-make backup_illumina.py able to take relative paths for --forward-reads argument

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # seqBackup
+
+Works with Python 2, NOT Python 3
+
+## TODO: update for Python 3

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # seqBackup
 
-Works with Python 2, NOT Python 3
+`python -m unittests` to run tests.
 
-## TODO: 
--update for Python 3
+## TODO:
+
 -make backup_illumina.py able to take relative paths for --forward-reads argument

--- a/seqBackupLib/backup.py
+++ b/seqBackupLib/backup.py
@@ -5,6 +5,7 @@ import stat
 import re
 import gzip
 import hashlib
+import warnings
 
 from seqBackupLib.illumina import IlluminaFastq
 
@@ -31,7 +32,7 @@ def return_md5(fname):
 
 def backup_fastq(forward_reads, dest_dir, sample_sheet_fp, has_index, min_file_size):
     
-    R1 = IlluminaFastq(gzip.GzipFile(forward_reads))    
+    R1 = IlluminaFastq(gzip.open(forward_reads, mode = 'rt'))    
 
     # build the strings for the required files    
     file_names_RI = build_fp_to_archive(forward_reads, has_index, R1.lane)
@@ -39,7 +40,7 @@ def backup_fastq(forward_reads, dest_dir, sample_sheet_fp, has_index, min_file_s
     # create the Illumina objects and check the files
     illumina_fastqs = []
     for fp in file_names_RI:
-        illumina_temp = IlluminaFastq(gzip.GzipFile(fp))
+        illumina_temp = IlluminaFastq(gzip.open(fp, mode = 'rt'))
         if not illumina_temp.check_fp_vs_content():
             raise ValueError("The file path and header infromation don't match")
         if not illumina_temp.check_file_size(min_file_size):

--- a/test/test_backup.py
+++ b/test/test_backup.py
@@ -18,10 +18,10 @@ class BackupTests(unittest.TestCase):
 
     def test_build_fp_to_archive(self):
         list1 = build_fp_to_archive("Undetermined_S0_L001_R1_001.fastq.gz", True, "1")
-        self.assertItemsEqual(list1, ["Undetermined_S0_L001_R1_001.fastq.gz", "Undetermined_S0_L001_R2_001.fastq.gz", "Undetermined_S0_L001_I1_001.fastq.gz", "Undetermined_S0_L001_I2_001.fastq.gz"])
+        self.assertCountEqual(list1, ["Undetermined_S0_L001_R1_001.fastq.gz", "Undetermined_S0_L001_R2_001.fastq.gz", "Undetermined_S0_L001_I1_001.fastq.gz", "Undetermined_S0_L001_I2_001.fastq.gz"])
         
         list1 = build_fp_to_archive("Undetermined_S0_L001_R1_001.fastq.gz", False, "1")
-        self.assertItemsEqual(list1, ["Undetermined_S0_L001_R1_001.fastq.gz", "Undetermined_S0_L001_R2_001.fastq.gz"])
+        self.assertCountEqual(list1, ["Undetermined_S0_L001_R1_001.fastq.gz", "Undetermined_S0_L001_R2_001.fastq.gz"])
 
     def test_backup_fastq(self):
         has_index = True
@@ -29,7 +29,7 @@ class BackupTests(unittest.TestCase):
         backup_fastq(self.fastq_filepath, self.temp_out_dir, self.sample_sheet_fp, has_index, min_file_size)
         
         # check the md5sums of the first fastq is the same
-        fq = IlluminaFastq(gzip.GzipFile(self.fastq_filepath))
+        fq = IlluminaFastq(gzip.open(self.fastq_filepath, mode = 'rt'))
         out_fp = os.path.join(self.temp_out_dir, fq.build_archive_dir(), os.path.basename(self.fastq_filepath))
         md5_orj = return_md5(self.fastq_filepath)
         md5_trans = return_md5(out_fp)

--- a/test/test_illumina.py
+++ b/test/test_illumina.py
@@ -149,7 +149,7 @@ class IlluminaTests(unittest.TestCase):
     def test_check_file_size(self):
         curr_dir = os.path.dirname(os.path.abspath(__file__))
         fastq_filepath = os.path.join(curr_dir, "170323_M04734_0028_000000000-B2MVT/Undetermined_S0_L001_R1_001.fastq.gz")
-        fq = IlluminaFastq(gzip.GzipFile(fastq_filepath))
+        fq = IlluminaFastq(gzip.open(fastq_filepath, mode = 'rt'))
         self.assertTrue(fq.check_file_size(50))
         self.assertFalse(fq.check_file_size(50000))
 


### PR DESCRIPTION
-Used gzip.open with mode = 'rt' to properly read text in fastq.gz
-AssertItemEqual is deprecated since python 2.7
-Updated readme and tests to make it easier to run them