### PR TITLE
Add SH machine type

### DIFF
--- a/seqBackupLib/illumina.py
+++ b/seqBackupLib/illumina.py
@@ -10,6 +10,7 @@ MACHINE_TYPES = {
     "A": "Illumina-NovaSeq",
     "NB": "Illumina-MiniSeq",
     "LH": "Illumina-NovaSeqX",
+    "SH": "Illumina-MiSeq",
 }
 
 
@@ -35,9 +36,10 @@ class IlluminaDir:
             raise ValueError(f"Invalid date format in run name: {date}")
 
         instrument = parts[1]
-        if extract_instrument_code(instrument) not in MACHINE_TYPES:
+        instrument_code = extract_instrument_code(instrument)
+        if instrument_code not in MACHINE_TYPES:
             raise ValueError(f"Invalid instrument code in run name: {instrument}")
-        self.machine_type = MACHINE_TYPES[extract_instrument_code(instrument)]
+        self.machine_type = MACHINE_TYPES[instrument_code]
 
         run_number = parts[2]
         if not run_number.isdigit():
@@ -55,12 +57,7 @@ class IlluminaDir:
             "flowcell_id": flowcell_id,
         }
 
-        if (
-            self.machine_type == "Illumina-HiSeq"
-            or self.machine_type == "Illumina-NovaSeq"
-            or self.machine_type == "Illumina-MiniSeq"
-            or self.machine_type == "Illumina-NovaSeqX"
-        ):
+        if instrument_code in {"D", "A", "NB", "LH", "SH"}:
             vals1["flowcell_id"] = vals1["flowcell_id"][1:]
 
         return vals1

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -119,6 +119,20 @@ def nextseq_dir(tmp_path) -> Path:
 
 
 @pytest.fixture
+def sh_dir(tmp_path) -> Path:
+    return setup_illumina_dir(
+        tmp_path / "20250610_SH00024_0006_ASC2107697-SC3",
+        "Undetermined_S0_L001_R1_001.fastq.gz",
+        [
+            "@SH00024:6:SC2107697-SC3:1:1101:18286:1000 1:N:0:ACGT+ACGT\n",
+            "ACGT\n",
+            "+\n",
+            "IIII\n",
+        ],
+    )
+
+
+@pytest.fixture
 def full_miseq_dir(tmp_path) -> Path:
     # Lane 1
     setup_illumina_dir(

--- a/test/test_illumina.py
+++ b/test/test_illumina.py
@@ -12,6 +12,7 @@ machine_fixtures = {
     "M": "miseq_dir",
     "NB": "miniseq_dir",
     "VH": "nextseq_dir",
+    "SH": "sh_dir",
 }
 
 


### PR DESCRIPTION
## Summary
- support SH instrument codes in Illumina parsing
- provide fixture data for SH runs
- cover new machine type in tests
- treat SH as another MiSeq model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687aaf9375888323b870e418a3db04c0