### PR TITLE
Add Docker image build and publish automation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ctbushman/seqbackup
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+WORKDIR /app
+
+# Install the seqBackup package and its dependencies
+COPY pyproject.toml README.md ./
+COPY seqBackupLib ./seqBackupLib
+RUN pip install --upgrade pip \
+    && pip install .
+
+ENTRYPOINT ["backup_illumina"]
+CMD ["--help"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs seqBackup and exposes the backup_illumina CLI
- create a GitHub Actions workflow to build and push the Docker image to Docker Hub

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dec6a988f8832385d47dc80e8f1570