### PR TITLE
Add TSV-backed machine type loader with in-memory cache and fallback warnings

### DIFF
--- a/seqBackupLib/illumina.py
+++ b/seqBackupLib/illumina.py
@@ -2,7 +2,6 @@ import csv
 import re
 import warnings
 from collections.abc import Mapping
-from typing import Optional
 from io import TextIOWrapper
 from pathlib import Path
 from urllib.error import URLError
@@ -22,7 +21,6 @@ MACHINE_TYPES_URL = (
     "https://raw.githubusercontent.com/PennChopMicrobiomeProgram/"
     "SampleRegistry/master/sample_registry/data/machine_types.tsv"
 )
-_machine_types_cache: Optional[dict[str, str]] = None
 
 
 class MachineTypesMapping(Mapping):
@@ -40,10 +38,6 @@ class MachineTypesMapping(Mapping):
 
 
 def load_machine_types() -> dict[str, str]:
-    global _machine_types_cache
-    if _machine_types_cache is not None:
-        return _machine_types_cache
-
     try:
         with urlopen(MACHINE_TYPES_URL, timeout=10) as response:
             content = response.read().decode("utf-8")
@@ -52,8 +46,7 @@ def load_machine_types() -> dict[str, str]:
             f"Falling back to bundled machine types; unable to load {MACHINE_TYPES_URL}: {exc}",
             RuntimeWarning,
         )
-        _machine_types_cache = MACHINE_TYPES_FALLBACK
-        return _machine_types_cache
+        return MACHINE_TYPES_FALLBACK
 
     reader = csv.reader(content.splitlines(), delimiter="\t")
     rows = [row for row in reader if row]
@@ -62,8 +55,7 @@ def load_machine_types() -> dict[str, str]:
             "Falling back to bundled machine types; received empty machine_types.tsv.",
             RuntimeWarning,
         )
-        _machine_types_cache = MACHINE_TYPES_FALLBACK
-        return _machine_types_cache
+        return MACHINE_TYPES_FALLBACK
 
     if rows[0][0].lower() in {"instrument_code", "code"}:
         rows = rows[1:]
@@ -82,11 +74,9 @@ def load_machine_types() -> dict[str, str]:
             "Falling back to bundled machine types; no valid rows in machine_types.tsv.",
             RuntimeWarning,
         )
-        _machine_types_cache = MACHINE_TYPES_FALLBACK
-        return _machine_types_cache
+        return MACHINE_TYPES_FALLBACK
 
-    _machine_types_cache = mapping
-    return _machine_types_cache
+    return mapping
 
 
 MACHINE_TYPES = MachineTypesMapping()

--- a/seqBackupLib/illumina.py
+++ b/seqBackupLib/illumina.py
@@ -2,6 +2,7 @@ import csv
 import re
 import warnings
 from collections.abc import Mapping
+from typing import Optional
 from io import TextIOWrapper
 from pathlib import Path
 from urllib.error import URLError
@@ -21,7 +22,7 @@ MACHINE_TYPES_URL = (
     "https://raw.githubusercontent.com/PennChopMicrobiomeProgram/"
     "SampleRegistry/master/sample_registry/data/machine_types.tsv"
 )
-_machine_types_cache: dict[str, str] | None = None
+_machine_types_cache: Optional[dict[str, str]] = None
 
 
 class MachineTypesMapping(Mapping):


### PR DESCRIPTION
### Motivation
- Use an authoritative remote `machine_types.tsv` to resolve Illumina instrument codes instead of a hardcoded map. 
- Keep behavior robust when the remote resource is unavailable by falling back to a bundled mapping and warning the user. 
- Avoid disk caching and keep a simple in-memory cache for runtime efficiency.

### Description
- Add `MACHINE_TYPES_FALLBACK` (bundled fallback), `MACHINE_TYPES_URL`, and an in-memory cache `_machine_types_cache` with a new `load_machine_types()` loader that fetches and parses the TSV via `urlopen` and `csv` and warns on fallback. 
- Replace direct uses of the old mapping with calls to `load_machine_types()` in `IlluminaDir._parse_folder`, `IlluminaFastq.machine_type`, and the run-name detection logic. 
- Emit `warnings.warn` messages when the remote TSV cannot be loaded or contains no valid rows, and document the fallback mapping inline with a comment. 
- Add necessary imports (`csv`, `warnings`, `URLError`, `urlopen`) and keep caching only in-memory (no disk writes).

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb626e55483238bec0ff4db623063)